### PR TITLE
Nguyen/test approvia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+## Version 3.11.0
+
+_2025-04-09_
+
+ * Fix: Clear the deflater's byte array reference
+ * New: Faster implementation of `String.decodeHex()` on Kotlin/JS.
+ * New: Declare `EXACTLY_ONCE` execution for blocks like `Closeable.use {}` and `FileSystem.read {}`.
+ * Upgrade: [Kotlin 2.1.20][kotlin_2_1_20].
+
+
 ## Version 3.10.2
 
 _2025-01-08_
@@ -951,6 +961,7 @@ _2014-04-08_
 [kotlin_1_9_0]: https://kotlinlang.org/docs/whatsnew19.html
 [kotlin_1_9_10]: https://github.com/JetBrains/kotlin/releases/tag/v1.9.10
 [kotlin_1_9_21]: https://github.com/JetBrains/kotlin/releases/tag/v1.9.21
+[kotlin_2_1_20]: https://github.com/JetBrains/kotlin/releases/tag/v2.1.20
 [loom]: https://wiki.openjdk.org/display/loom/Getting+started
 [maven_provided]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html
 [preview1]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ Releases
 Our [change log][changelog] has release history.
 
 ```kotlin
-implementation("com.squareup.okio:okio:3.10.2")
+implementation("com.squareup.okio:okio:3.11.0")
 ```
 
 <details>
@@ -110,7 +110,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.squareup.okio:okio:3.11.0-SNAPSHOT")
+  implementation("com.squareup.okio:okio:3.11.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.mpp.commonizerLogLevel=info
 kotlin.mpp.stability.nowarn=true
 
 GROUP=com.squareup.okio
-VERSION_NAME=3.11.0
+VERSION_NAME=3.12.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.mpp.commonizerLogLevel=info
 kotlin.mpp.stability.nowarn=true
 
 GROUP=com.squareup.okio
-VERSION_NAME=3.11.0-SNAPSHOT
+VERSION_NAME=3.11.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
 kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.2" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.3" }
 test-assertj = { module = "org.assertj:assertj-core", version = "3.27.3" }
 test-assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 test-jimfs = "com.google.jimfs:jimfs:1.3.0"

--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -158,13 +158,13 @@ kotlin {
           }
           createSourceSet("unixMain", parent = nativeMain)
             .also { unixMain ->
+              unixMain.dependsOn(nonJsMain)
               createSourceSet(
                   "linuxMain",
                   parent = unixMain,
                   children = linuxTargets,
               ).also { linuxMain ->
                 linuxMain.dependsOn(nonAppleMain)
-                linuxMain.dependsOn(nonJsMain)
               }
               createSourceSet("appleMain", parent = unixMain, children = appleTargets)
             }

--- a/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
+++ b/okio/src/jvmMain/kotlin/okio/DeflaterSink.kt
@@ -18,6 +18,7 @@
 package okio
 
 import java.util.zip.Deflater
+import okio.internal.EMPTY_BYTE_ARRAY
 
 actual class DeflaterSink internal actual constructor(
   private val sink: BufferedSink,
@@ -51,6 +52,10 @@ actual class DeflaterSink internal actual constructor(
 
       remaining -= toDeflate
     }
+
+    // Deflater still holds a reference to the most recent segment's byte array. That can cause
+    // problems in JNI, so clear it now. https://github.com/square/okio/issues/1608
+    deflater.setInput(EMPTY_BYTE_ARRAY, 0, 0)
   }
 
   private fun deflate(syncFlush: Boolean) {

--- a/okio/src/jvmMain/kotlin/okio/internal/-ZlibJvm.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/-ZlibJvm.kt
@@ -36,3 +36,5 @@ internal actual fun datePartsToEpochMillis(
   calendar.set(year, month - 1, day, hour, minute, second)
   return calendar.time.time
 }
+
+internal val EMPTY_BYTE_ARRAY = byteArrayOf()

--- a/okio/src/nonJsMain/kotlin/okio/internal/ByteStringNonJs.kt
+++ b/okio/src/nonJsMain/kotlin/okio/internal/ByteStringNonJs.kt
@@ -41,4 +41,3 @@ private fun decodeHexDigit(c: Char): Int {
     else -> throw IllegalArgumentException("Unexpected hex digit: $c")
   }
 }
-


### PR DESCRIPTION
This PR updates Okio to version 3.12.0-SNAPSHOT and includes several enhancements and dependency updates.

<details>
<summary>Enhancements</summary>

*   Updates Okio version to 3.12.0-SNAPSHOT.
*   Fixes an issue where `Deflater` held a reference to a byte array.
*   Implements a faster `String.decodeHex()` on Kotlin/JS.
*   Declares `EXACTLY_ONCE` execution for specific blocks.
*   Upgrades to Kotlin 2.1.20.
*   Updates the spotless plugin version to 7.0.3.

</details>